### PR TITLE
Added a Saving Mechanism

### DIFF
--- a/Assets/Configs/NewGame.json
+++ b/Assets/Configs/NewGame.json
@@ -1,0 +1,7 @@
+{
+    "GardenRecord" : {
+        "Version" : 0,
+        "Tomatoes" : 30
+    }
+
+}

--- a/Assets/Configs/NewGame.json.meta
+++ b/Assets/Configs/NewGame.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8a6bc681c795c4260b01fb24f552a763
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Configs/PlayerAccount.asset
+++ b/Assets/Configs/PlayerAccount.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 085af60c0b01243eaa5405580c98cb79, type: 3}
+  m_Name: PlayerAccount
+  m_EditorClassIdentifier: 
+  _config:
+    CreateNewPlayerAutomatically: 1
+    NewPlayerRecords: {fileID: 0}

--- a/Assets/Configs/PlayerAccount.asset.meta
+++ b/Assets/Configs/PlayerAccount.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 452326133af3e4f70ad612dcfd20c389
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player Data.meta
+++ b/Assets/Player Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d974bc33c0eb243d8889d06e6bde5222
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player Data/GardenRecord.json
+++ b/Assets/Player Data/GardenRecord.json
@@ -1,0 +1,5 @@
+{
+  "Tomatoes": 30,
+  "Id": "GardenRecord",
+  "Version": 0
+}

--- a/Assets/Player Data/GardenRecord.json.meta
+++ b/Assets/Player Data/GardenRecord.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04fe5933030e747ffa8d18016a698a92
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player Data/PlayerAccountRecord.json
+++ b/Assets/Player Data/PlayerAccountRecord.json
@@ -1,0 +1,5 @@
+{
+  "PlayerId": "1775505612",
+  "Id": "PlayerAccountRecord",
+  "Version": 0
+}

--- a/Assets/Player Data/PlayerAccountRecord.json.meta
+++ b/Assets/Player Data/PlayerAccountRecord.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 67ed63a0e254e4f779629f81a350fe53
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Configs/LocalConfigs.asset
+++ b/Assets/Resources/Configs/LocalConfigs.asset
@@ -15,3 +15,4 @@ MonoBehaviour:
   Configs:
   - {fileID: 11400000, guid: 41852105b0a034a88868009f574463ff, type: 2}
   - {fileID: 11400000, guid: fb8797221797e3c42926032fb4346b53, type: 2}
+  - {fileID: 11400000, guid: 452326133af3e4f70ad612dcfd20c389, type: 2}

--- a/Assets/Scripts/Agents/Logout.meta
+++ b/Assets/Scripts/Agents/Logout.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a75224cbf189f4eeeb921e99a48be12c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Agents/Logout/ILogoutAgent.cs
+++ b/Assets/Scripts/Agents/Logout/ILogoutAgent.cs
@@ -1,0 +1,10 @@
+using Core;
+
+namespace Agents
+{
+    public interface ILogoutAgent : IAgent
+    {
+        //Add Your Agent API Here
+        void Logout();
+    }
+}

--- a/Assets/Scripts/Agents/Logout/ILogoutAgent.cs.meta
+++ b/Assets/Scripts/Agents/Logout/ILogoutAgent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2774af70b0fa04e73b4af41c7c73eabc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Agents/Logout/LogoutAgent.cs
+++ b/Assets/Scripts/Agents/Logout/LogoutAgent.cs
@@ -1,0 +1,20 @@
+using Core;
+
+namespace Agents
+{
+    public class LogoutAgent : BaseAgent<ILogoutAgent>, ILogoutAgent
+    {
+        public void Logout()
+        {
+            foreach (var feature in _features)
+            {
+                feature.Logout();
+            }
+
+            foreach (var service in _services)
+            {
+                service.Logout();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Agents/Logout/LogoutAgent.cs.meta
+++ b/Assets/Scripts/Agents/Logout/LogoutAgent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8360739723e2942c28914a7d8056ecc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Infra/BaseFeature.cs
+++ b/Assets/Scripts/Core/Infra/BaseFeature.cs
@@ -9,6 +9,7 @@ namespace Core
         private static readonly Type _injectType = typeof(InjectAttribute);
         private static readonly Type _featureType = typeof(IFeature);
         private static readonly Type _serviceType = typeof(IService);
+        private static readonly Type _agentType = typeof(IAgent);
         private static readonly Type _recordType = typeof(BaseRecord);
         
         public virtual void Bootstrap(IBootstrap bootstrap)
@@ -37,6 +38,11 @@ namespace Core
                     {
                         var record = bootstrap.Records[propertyType];
                         property.SetValue(this, record);
+                    }
+                    else if (_agentType.IsAssignableFrom(propertyType))
+                    {
+                        var agent = bootstrap.Agents.Get(propertyType);
+                        property.SetValue(this, agent);
                     }
                     else
                     {

--- a/Assets/Scripts/Core/Infra/BaseRecord.cs
+++ b/Assets/Scripts/Core/Infra/BaseRecord.cs
@@ -1,4 +1,5 @@
 using Unity.Plastic.Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json.Linq;
 
 namespace Core
 {
@@ -10,6 +11,12 @@ namespace Core
         public void Populate(string json)
         {
             JsonConvert.PopulateObject(json, this);
+        }
+
+        public void Populate(JObject o)
+        {
+            using var jsonReader = o.CreateReader();
+            JsonSerializer.Create().Populate(jsonReader, this);
         }
     }
 }

--- a/Assets/Scripts/Features/Garden/GardenRecord.cs
+++ b/Assets/Scripts/Features/Garden/GardenRecord.cs
@@ -4,6 +4,6 @@ namespace Game
 {
     public class GardenRecord : BaseRecord
     {
-
+        public int Tomatoes { get; set; }
     }
 }

--- a/Assets/Scripts/Features/PlayerAccount.meta
+++ b/Assets/Scripts/Features/PlayerAccount.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9c593d7fdecc4a6fb21bb92d95ffba6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Features/PlayerAccount/IPlayerAccount.cs
+++ b/Assets/Scripts/Features/PlayerAccount/IPlayerAccount.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Core;
+
+namespace Game
+{
+    public interface IPlayerAccount : IFeature
+    {
+        bool IsLoggedIn { get; }
+        string PlayerId { get; }
+        
+        Task Login();
+        Task Logout();
+        
+        //Task LinkCredentials(); 
+
+        Task CreateNewPlayer();
+        Task SyncPlayerData();
+    }
+}

--- a/Assets/Scripts/Features/PlayerAccount/IPlayerAccount.cs.meta
+++ b/Assets/Scripts/Features/PlayerAccount/IPlayerAccount.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4110e28b96ae44cbaaeee74ca916cc43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccount.cs
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccount.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Agents;
+using Core;
+using Services;
+using Unity.Plastic.Newtonsoft.Json;
+using Unity.Plastic.Newtonsoft.Json.Linq;
+
+namespace Game
+{
+    public class PlayerAccount : BaseFeature, IPlayerAccount, IAppLaunchAgent
+    {
+        [Inject] public PlayerAccountRecord Record { get; set; }
+        [Inject] public IPlayerSaveService Saver { get; set; }
+        [Inject] public ILocalConfigService ConfigService { get; set; }
+        
+        [Inject] public ILogoutAgent LogoutAgent { get; set; }
+
+        public bool IsLoggedIn => Record.PlayerId.HasContent();
+        public string PlayerId => Record.PlayerId;
+        
+        public PlayerAccountConfig Config { get; set; }
+        
+        public Task AppLaunch()
+        {
+            Config = ConfigService.GetConfig<PlayerAccountConfig>();
+            return Task.CompletedTask;
+        }
+
+        public async Task Login()
+        {
+            if (IsLoggedIn)
+            {
+                await SyncPlayerData();
+                await Logout();
+            }
+
+            var savedPlayerAccount = await Saver.GetSavedJson(Record.Id);
+            if (savedPlayerAccount.IsNullOrEmpty())
+            {
+                if (Config.CreateNewPlayerAutomatically)
+                {
+                    await CreateNewPlayer();
+                    await SyncPlayerData();
+                }
+            }
+            else
+            {
+                Record.Populate(savedPlayerAccount);
+            }
+
+            var records = Saver.RecordsForSaving;
+            foreach (var record in records)
+            {
+                var saveJson = await Saver.GetSavedJson(record.Id);
+                record.Populate(saveJson);
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(0.1f)); //Intentional delay to test loading
+        }
+
+        public Task Logout()
+        {
+            LogoutAgent.Logout();
+
+            Record.Reset();
+
+            return Task.CompletedTask;
+        }
+
+        public Task CreateNewPlayer()
+        {
+            Record.PlayerId = Guid.NewGuid().GetHashCode().ToString();
+
+            var records = JsonConvert.DeserializeObject<Dictionary<string, JObject>>(Config.NewPlayerRecords.text);
+
+            foreach (var recordKVP in records)
+            {
+                var recordToStart = Saver.RecordsForSaving.First(r => r.Id == recordKVP.Key);
+                recordToStart.Populate(recordKVP.Value);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public async Task SyncPlayerData()
+        {
+            var records = Saver.RecordsForSaving;
+            foreach (var record in records)
+            {
+                await Saver.SaveData(record, record.Id);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccount.cs.meta
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccount.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72d178d400f80477d8daa85ca7f58355
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccountConfig.cs
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccountConfig.cs
@@ -1,0 +1,14 @@
+using Core;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace Game
+{
+    [System.Serializable]
+    public class PlayerAccountConfig : BaseConfig
+    {
+        public bool CreateNewPlayerAutomatically;
+
+        public TextAsset NewPlayerRecords;
+    }
+}

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccountConfig.cs.meta
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccountConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7588f9f0ed98344449d41738560d6cca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccountRecord.cs
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccountRecord.cs
@@ -1,0 +1,14 @@
+using Core;
+
+namespace Game
+{
+    public class PlayerAccountRecord : BaseRecord
+    {
+        public string PlayerId { get; set; }
+
+        public void Reset()  //TODO: Add a Test that Resets makes this record the same as a New() record
+        {
+            PlayerId = null;
+        }
+    }
+}

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccountRecord.cs.meta
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccountRecord.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31092cd59ee37497e801d637ccf5af0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccountSO.cs
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccountSO.cs
@@ -1,0 +1,13 @@
+using Core;
+using Services;
+using UnityEngine;
+
+namespace Game
+{
+    public class PlayerAccountSO : BaseConfigSO
+    {
+        [SerializeField] private PlayerAccountConfig _config;
+
+        public override BaseConfig Config => _config;
+    }
+}

--- a/Assets/Scripts/Features/PlayerAccount/PlayerAccountSO.cs.meta
+++ b/Assets/Scripts/Features/PlayerAccount/PlayerAccountSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 085af60c0b01243eaa5405580c98cb79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Flows/GameLaunchFlow.cs
+++ b/Assets/Scripts/Flows/GameLaunchFlow.cs
@@ -11,6 +11,7 @@ namespace Game
         {
             var joystick = bootstrap.Features.Get<IJoystick>();
             var avatar = bootstrap.Features.Get<IAvatar>();
+            var playerAccount = bootstrap.Features.Get<IPlayerAccount>();
             
              AddNext(action: () => bootstrap.Agents.Get<IAppLaunchAgent>().AppLaunch())
             .AddNext(() => { bootstrap.Features.Get<ILoadingScreen>().Show(true); })
@@ -18,7 +19,7 @@ namespace Game
 
             .AddNext(() => { return Task.Delay(TimeSpan.FromSeconds(0.5f)); })
             .AddNext(() => { bootstrap.Features.Get<ILoadingScreen>().ProgressControl(0.2f); })
-            .AddNext(() => { return Task.Delay(TimeSpan.FromSeconds(0.5f)); })
+            .AddNext(() => playerAccount.Login())
             .AddNext(() => { bootstrap.Features.Get<ILoadingScreen>().ProgressControl(0.4f); })
             .AddNext(() => { return Task.Delay(TimeSpan.FromSeconds(0.5f)); })
             .AddNext(() => { bootstrap.Features.Get<ILoadingScreen>().ProgressControl(0.6f); })

--- a/Assets/Scripts/Services/LocalConfig/LocalConfigService.cs
+++ b/Assets/Scripts/Services/LocalConfig/LocalConfigService.cs
@@ -16,7 +16,12 @@ namespace Services
             where T : BaseConfig
         {
             var configs = _so.Configs;
-            var configSO = configs.First(c => c.Config.GetType() == typeof(T));
+            var configSO = configs.FirstOrDefault(c => c.Config.GetType() == typeof(T));
+            if (configSO == null)
+            {
+                Notebook.NoteError("You might have forgotten to add your Config SO to the Local Config group SO for config type " + typeof(T));
+                return null;
+            }
             var result = (T)configSO.Config;
             return result;
         }

--- a/Assets/Scripts/Services/PlayerSave/IPlayerSaveService.cs
+++ b/Assets/Scripts/Services/PlayerSave/IPlayerSaveService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Core;
 
@@ -5,6 +6,9 @@ namespace Services
 {
     public interface IPlayerSaveService : IService
     {
+        void AddSaveRecord(BaseRecord record);
+        List<BaseRecord> RecordsForSaving { get; }
+        
         Task<T> GetSavedData<T>(string saveId);
 
         Task<string> GetSavedJson(string saveId);

--- a/Assets/Scripts/Services/PlayerSave/PlayerSaveService.cs
+++ b/Assets/Scripts/Services/PlayerSave/PlayerSaveService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Core;
@@ -8,6 +9,13 @@ namespace Services
 {
     public class PlayerSaveService : BaseService, IPlayerSaveService
     {
+        public void AddSaveRecord(BaseRecord record)
+        {
+            RecordsForSaving.Add(record);
+        }
+
+        public List<BaseRecord> RecordsForSaving { get; } = new();
+
         public async Task<T> GetSavedData<T>(string saveId)
         {
             var saveText = await GetSavedJson(saveId);

--- a/Assets/Scripts/System/GameBootstrap.cs
+++ b/Assets/Scripts/System/GameBootstrap.cs
@@ -26,6 +26,7 @@ namespace Game
             _features.Add<IGarden>(new Garden());
             _features.Add<IAvatar>(new Avatar());
             _features.Add<IJoystick>(new Joystick());
+            _features.Add<IPlayerAccount>(new PlayerAccount());
             //<New Feature>
         }
 
@@ -41,6 +42,7 @@ namespace Game
         {
             _agents.Add<IAppLaunchAgent>(new AppLaunchAgent());
             _agents.Add<IAppExitAgent>(new AppExitAgent());
+            _agents.Add<ILogoutAgent>(new LogoutAgent());
             //<New Agent>
         }
 
@@ -50,6 +52,7 @@ namespace Game
             _records.Add(typeof(GardenRecord), new GardenRecord());
             _records.Add(typeof(AvatarRecord), new AvatarRecord());
             _records.Add(typeof(JoystickRecord), new JoystickRecord());
+            _records.Add(typeof(PlayerAccountRecord), new PlayerAccountRecord());
             //<New Record>
         }
 
@@ -58,8 +61,18 @@ namespace Game
             BootstrapRecordService();
             BootstrapSummoningService();
             BootstrapLocalConfigurationService();
+            BootstrapSavedRecords();
 
             AppExitAgent.SelfRegister(_agents.Get<IAppExitAgent>());
+        }
+
+        //If you want your Record to be saved, add your Record here
+        private void BootstrapSavedRecords()
+        {
+            var saveService = _services.Get<IPlayerSaveService>();
+            
+            saveService.AddSaveRecord(_records[typeof(GardenRecord)]);
+            saveService.AddSaveRecord(_records[typeof(PlayerAccountRecord)]);
         }
 
         private void BootstrapRecordService()


### PR DESCRIPTION
In this PR we added a new Feature, for Player Account.

- Now we can Login which we do in the Game Launch Flow
- Also added new Bootstrap Step to add any records to the Saving Features, So we can now add Records to be Saved in the Bootstrap
![image](https://github.com/user-attachments/assets/07b8b2cb-1e83-48ad-a8e5-41aa0773b8e0)
In this example we have now two Records to be saved by the Save System. In the Bootstrap we assign these records to be saved.

- The Save Mechanism currently works with Game Files which we can view in the Inspector
![image](https://github.com/user-attachments/assets/5dfc9dbd-a07e-4f48-a14d-0096209be345)
These files are our Save Data for each Record

- Also we can now set how the game will start with the Records.
![image](https://github.com/user-attachments/assets/d267ecdd-cf05-46a7-83b3-be3a1c527201)
This will be applied if we start a new User.

- the IPlayerAccount will be used to operate the Save Data.
